### PR TITLE
Update landing page with draft agenda.

### DIFF
--- a/_posts/2013-04-29-uwmadison/index.html
+++ b/_posts/2013-04-29-uwmadison/index.html
@@ -252,8 +252,6 @@ title: University of Wisconsin-Madison 2013
            Paul Wilson, 
            <a href="http://wid.wisc.edu/profile/lauren-michael/">Lauren Michael</a>, 
            <a href="http://www.ncl.ac.uk/computing/people/profile/stephen.mcgough">Stephen McGough</a>, 
-           as well as old hat
-           <a href="http://katyhuff.github.com">Katy Huff</a>, 
            and new(ish) blood:
            <a href="http://gidden.github.com">Matt Gidden</a>, and
            Aronne Merrelli.

--- a/_posts/2013-04-29-uwmadison/index.html
+++ b/_posts/2013-04-29-uwmadison/index.html
@@ -77,7 +77,11 @@ title: University of Wisconsin-Madison 2013
       <div id="schedule" class="row-fluid">
         <h1>Schedule</h1>
         <p class="muted" style="font-style: italic;">Subject to Change</p>
-        <div class="span4">
+	<p>This bootcamp has been structured around the concepts put forth in the recent paper 
+	  "<a href="http://arxiv.org/abs/1210.0530">Best Practices for Scientific Computing</a>" by G. Wilson, et al.
+          In so doing, the sessions names have been chosen to correspond with some of the most important 
+          practices to start early.</p>
+        <div class="span6">
           <strong>Day 1</strong>
           <table class="table">
             <tbody>
@@ -99,7 +103,7 @@ title: University of Wisconsin-Madison 2013
               </tr>
               <tr>
                 <td>11:00 - 12:30</td>
-                <td style="text-align: right;">Automating workflows</td>
+                <td style="text-align: right;">Automating workflows <br/ ><span class="muted">(Shell scripts & Makefiles)</span></td>
               </tr>
               <tr>
                 <td>12:30 - 1:30</td>
@@ -107,7 +111,7 @@ title: University of Wisconsin-Madison 2013
               </tr>
               <tr>
                 <td>1:30 - 3:00</td>
-                <td style="text-align: right;">Write Code for People</td>
+                <td style="text-align: right;">Write Code for People I<br/ ><span class="muted">(Variables & Data Structures)</span></td>
               </tr>
               <tr>
                 <td>3:00 - 3:15</td>
@@ -115,7 +119,7 @@ title: University of Wisconsin-Madison 2013
               </tr>
               <tr>
                 <td>3:15 - 4:30</td>
-                <td style="text-align: right;">Write Code for People</td>
+                <td style="text-align: right;">Write Code for People II<br/ ><span class="muted">(Flow Control)</span></td>
               </tr>
             </tbody>
           </table>
@@ -124,7 +128,7 @@ title: University of Wisconsin-Madison 2013
             <tbody>
               <tr>
                 <td>9:00 - 10:30</td>
-                <td style="text-align: right;">Don't Repeat Yourself</td>
+                <td style="text-align: right;">Don't Repeat Yourself<br/ ><span class="muted">(Functions & Modules)</span></td>
               </tr>
               <tr>
                 <td>10:30 - 10:45</td>
@@ -132,7 +136,7 @@ title: University of Wisconsin-Madison 2013
               </tr>
               <tr>
                 <td>10:45 - 12:00</td>
-                <td style="text-align: right;">Plan for Mistakes</td>
+                <td style="text-align: right;">Plan for Mistakes<br/ ><span class="muted">(Testing)</span></td>
               </tr>
               <tr>
                 <td>12:00 - 1:00</td>
@@ -140,7 +144,7 @@ title: University of Wisconsin-Madison 2013
               </tr>
               <tr>
                 <td>1:00 - 2:30</td>
-                <td style="text-align: right;">Use Version Control</td>
+                <td style="text-align: right;">Use Version Control<br/ ><span class="muted">(Using git locally)</span></td>
               </tr>
               <tr>
                 <td>2:30 - 2:45</td>
@@ -148,7 +152,7 @@ title: University of Wisconsin-Madison 2013
               </tr>
               <tr>
                 <td>2:45 - 4:00</td>
-                <td style="text-align: right;">Collaborate</td>
+                <td style="text-align: right;">Collaborate<br/ ><span class="muted">(Using git remotely & github)</span></td>
               </tr>
             </tbody>
           </table>

--- a/_posts/2013-04-29-uwmadison/index.html
+++ b/_posts/2013-04-29-uwmadison/index.html
@@ -86,28 +86,36 @@ title: University of Wisconsin-Madison 2013
                 <td style="text-align: right;">Setup Help</td>
               </tr>
               <tr>
-                <td>9:00 - 10:30</td>
-                <td style="text-align: right;">The Shell</td>
+                <td>9:00 - 9:45</td>
+                <td style="text-align: right;">What we know about software engineering.</td>
               </tr>
               <tr>
-                <td>10:30 - 12:00</td>
-                <td style="text-align: right;">Python Variables</td>
+                <td>9:45 - 10:45</td>
+                <td style="text-align: right;">Introducing the Shell</td>
               </tr>
               <tr>
-                <td>12:00 - 1:00</td>
+                <td>10:45 - 11:00</td>
+                <td style="text-align: right;">Break</td>
+              </tr>
+              <tr>
+                <td>11:00 - 12:30</td>
+                <td style="text-align: right;">Automating workflows</td>
+              </tr>
+              <tr>
+                <td>12:30 - 1:30</td>
                 <td style="text-align: right;">Lunch</td>
               </tr>
               <tr>
-                <td>1:00 - 2:00</td>
-                <td style="text-align: right;">Python Data Structures</td>
+                <td>1:30 - 3:00</td>
+                <td style="text-align: right;">Write Code for People</td>
               </tr>
               <tr>
-                <td>2:00 - 3:00</td>
-                <td style="text-align: right;">Python Flow Control</td>
+                <td>3:00 - 3:15</td>
+                <td style="text-align: right;">Break</td>
               </tr>
               <tr>
-                <td>3:00 - 4:30</td>
-                <td style="text-align: right;">Python Functions and Modules</td>
+                <td>3:15 - 4:30</td>
+                <td style="text-align: right;">Write Code for People</td>
               </tr>
             </tbody>
           </table>
@@ -116,11 +124,15 @@ title: University of Wisconsin-Madison 2013
             <tbody>
               <tr>
                 <td>9:00 - 10:30</td>
-                <td style="text-align: right;">Version Control Local</td>
+                <td style="text-align: right;">Don't Repeat Yourself</td>
               </tr>
               <tr>
-                <td>10:30 - 12:00</td>
-                <td style="text-align: right;">Version Control Remote</td>
+                <td>10:30 - 10:45</td>
+                <td style="text-align: right;">Break</td>
+              </tr>
+              <tr>
+                <td>10:45 - 12:00</td>
+                <td style="text-align: right;">Plan for Mistakes</td>
               </tr>
               <tr>
                 <td>12:00 - 1:00</td>
@@ -128,15 +140,15 @@ title: University of Wisconsin-Madison 2013
               </tr>
               <tr>
                 <td>1:00 - 2:30</td>
-                <td style="text-align: right;">Debugging</td>
+                <td style="text-align: right;">Use Version Control</td>
               </tr>
               <tr>
-                <td>2:30 - 3:30</td>
-                <td style="text-align: right;">Testing</td>
+                <td>2:30 - 2:45</td>
+                <td style="text-align: right;">Break</td>
               </tr>
               <tr>
-                <td>3:30 - 4:30</td>
-                <td style="text-align: right;">Documentation</td>
+                <td>2:45 - 4:00</td>
+                <td style="text-align: right;">Collaborate</td>
               </tr>
             </tbody>
           </table>


### PR DESCRIPTION
During today's meeting we decided to arrange the schedule around the Best Practices paper (http://arxiv.org/abs/1210.0530).  After creating the list of 10 practices, some seemed more appropriate to a boot camp than others, and the shell doesn't really exist there at all...

Day 1
- Setup help (pre-workshop) [30 min]
- (Motivation) What we know about software engineering : @stevemcgough [45 min]
- The Shell : @gonuke [60 min]
- Automating Workflows == Shell automation and Makefiles : @gonuke [90 min]
- Write Code for People == Variables and Data Structures : @stevemcgough [90 min]
- Write Code for People (II) == Flow Control : @aronnem [75 min]

Day 2
- Don't Repeat Yourself == Functions & Modules : @aronnem [90 min]
- Plan for Mistakes == Testing : @katyhuff [75 min]
- Version Control == VC local : @gidden [90 min]
- Collaborate == VC remote : @gidden [75 min]

These are the proposed teaching assignments.  We hope that all instructors can frame their lessons in the context of the relevant "Best Practices" section.  We hope/expect that this will allow learners to make a better connection between the "how" and the "why".
