### PR TITLE
Fix broken links and those to outdated curriculum.

### DIFF
--- a/_posts/2014-01-13-uwmadison/index.html
+++ b/_posts/2014-01-13-uwmadison/index.html
@@ -112,20 +112,16 @@ title: University of Wisconsin-Madison 2014
                 <td style="text-align: right;">Lunch</td>
               </tr>
               <tr>
-                <td>12:45 - 2:15</td>
-                <td style="text-align: right;"><a href="https://github.com/UW-Madison-ACI/boot-camps/blob/2014-01-uwmadison/python/variables_and_types/Readme.md">Write Code for People I</a><br/ ><span class="muted">(Variables & Data Structures)</span></td>
+                <td>12:45 - 2:30</td>
+                <td style="text-align: right;"><a href="https://github.com/UW-Madison-ACI/boot-camps/blob/2014-01-uwmadison/python/writing_code_for_people/Readme.md">Write Code for People I</a><br/ ><span class="muted">(Variables & Data Structures)</span></td>
               </tr>
               <tr>
-                <td>2:15 - 3:00</td>
-                <td style="text-align: right;"><a href="https://github.com/UW-Madison-ACI/boot-camps/blob/2014-01-uwmadison/python/flow_control/Readme.md">Write Code for People II</a><br/ ><span class="muted">(Flow Control)</span></td>
-              </tr>
-              <tr>
-                <td>3:00 - 3:15</td>
+                <td>2:30 - 2:45</td>
                 <td style="text-align: right;">Break</td>
               </tr>
               <tr>
-                <td>3:15 - 4:30</td>
-                <td style="text-align: right;"><a href="https://github.com/UW-Madison-ACI/boot-camps/blob/2014-01-uwmadison/python/functions_and_modules/Readme.md">Don't Repeat Yourself</a><br/ ><span class="muted">(Functions & Modules)</span></td>
+                <td>2:45 - 4:30</td>
+                <td style="text-align: right;"><a href="https://github.com/UW-Madison-ACI/boot-camps/blob/2014-01-uwmadison/python/dont_repeat_yourself/Readme.md">Don't Repeat Yourself</a><br/ ><span class="muted">(Functions & Modules)</span></td>
               </tr>
             </tbody>
           </table>
@@ -146,7 +142,7 @@ title: University of Wisconsin-Madison 2014
               </tr>
 	          <tr>
                 <td>10:45 - 12:00</td>
-                <td style="text-align: right;"><a href="https://github.com/UW-Madison-ACI/boot-camps/blob/2014-01-uwmadison/version-control/python/testing/Readme.md">Plan for Mistakes</a><br/ ><span class="muted">(Testing & Debugging)</span></td>
+                <td style="text-align: right;"><a href="https://github.com/UW-Madison-ACI/boot-camps/blob/2014-01-uwmadison/python/testing/Readme.md">Plan for Mistakes</a><br/ ><span class="muted">(Testing & Debugging)</span></td>
               </tr>
               <tr>
                 <td>12:00 - 1:00</td>


### PR DESCRIPTION
I just realized that our front page schedule links to the wrong python material...  I fixed the links here, but that may have a big impact depending on what @wltrimbl has prepaerd.

This also fixes a bad link in day 2 and reworks the schedule on day 1.
