### PR TITLE
git/revert_and_branch: most commit -> most recent commit

### DIFF
--- a/version-control/git/local/Revert_and_branch.md
+++ b/version-control/git/local/Revert_and_branch.md
@@ -60,7 +60,7 @@ $ git status
 ```
 
 **Step 3**: Unstage the file with `git reset`; `HEAD` refers to the
-  most commit to the repository.
+  most recent commit to the repository.
 
 ```
 $ git reset HEAD README.md


### PR DESCRIPTION
Fix typo reported by @gidden in [issue #132](https://github.com/UW-Madison-ACI/boot-camps/issues/132).
