### PR TITLE
git/revert_branch: include *.pyc as example for .gitignore

### DIFF
--- a/version-control/git/local/Revert_and_branch.md
+++ b/version-control/git/local/Revert_and_branch.md
@@ -166,7 +166,7 @@ directory as part of your git repository.
 
 - Backup files automatically created by your editor (`*.bak` or `*~`)
 - Very large primary data files that don't change
-- Compiled code (`*.o`, `*.so`, `*.exe`)
+- Compiled code (`*.pyc`, `*.o`, `*.so`, `*.exe`)
 - Files that are derived from your code (for example,
   figures/graphs/images)
 


### PR DESCRIPTION
In discussion of files to _not_ track as part of git repository, should include `*.pyc` as example of compiled code to include in `.gitignore` file.
