### PR TITLE
python/best_practice: Fix column_labels to match data

### DIFF
--- a/python/best_practice/Readme.md
+++ b/python/best_practice/Readme.md
@@ -196,7 +196,7 @@ Add these lines above the others in your script:
 import sys
 filelist = sys.argv[1:]
 column_labels = ("ID","Reported","Age","Gender",
-                "State of Residence","Income","Education","Hours per week")
+                "State of residence","Income","Education","Hours per week")
 all_data = []
 ```
 


### PR DESCRIPTION
Related to an error in an email from Claudia; when I went through the lesson, I was getting

```
KeyError: 'State of Residence'
```

The current change fixes that. Claudia, however, had reported `KeyError: 'ID'`, which is a puzzle.
