### PR TITLE
changing instructions to checkout remote median correctly

### DIFF
--- a/version-control/git/collaborate/Readme.md
+++ b/version-control/git/collaborate/Readme.md
@@ -23,6 +23,7 @@ SWC followers, we'll be working in a branch, called `median`, which I will now
 create. Once I have, update your local copies and remotes:
 
     $ git fetch upstream
+    $ git branch median upstream/median
     $ git checkout median
     $ git push origin median
 


### PR DESCRIPTION
if you want to use the fetched median branch from "upstream" need to create branch locally before checking it out.  
